### PR TITLE
mutation and route for updating appointment status and location

### DIFF
--- a/src/core/routes/professor.ts
+++ b/src/core/routes/professor.ts
@@ -3,9 +3,11 @@ import express, { Request, Response, NextFunction, Router } from "express";
 import { Me } from "../../models/me";
 import { isLoggedIn, isProfessor, isStudent } from "../middleware/auth";
 import { checkIfUserExists, getAggregates, getAllProfessors, getAllStudents, getUserbyUsername } from "../../mongo/queries/users";
-import { addStudentToAdvisor, insertNewCourse, insertStudentCourse } from "../../mongo/mutations/professor";
+import { addStudentToAdvisor, insertNewCourse, insertStudentCourse, } from "../../mongo/mutations/professor";
+import { updateAppointmentStatusAndLocationById } from "../../mongo/mutations/appointment";
 import { BadRequestError, UnauthorizedError } from "../errors/user";
 import { ensureObjectId } from "../config/utils/mongohelper";
+import { AppointmentStatus } from "../../models/appointment";
 
 
 const router: Router = express.Router();
@@ -120,6 +122,39 @@ router.get('/aggregates', isLoggedIn, isProfessor, async(req:Request, res:Respon
     res.json({message: "You are not authorized"});
     throw new UnauthorizedError(`You are not authorized`);
   }
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post('/update-apointment-status', isLoggedIn, isProfessor, async(req:Request, res:Response, next: NextFunction) => {
+  try{
+    let me = req.session.Me;
+      if (me && me.username && me.username.length > 0) {
+        let appointmentId = req.body.appointmentId;
+        let appointmentStatus = req.body.appointmentStatus;
+        let appointmentLocation = req.body.appointmentLocation;
+
+        let appointmentStatusEnum: AppointmentStatus;
+        switch (appointmentStatus) {
+          case AppointmentStatus.Pending:
+          case AppointmentStatus.Accepted:
+          case AppointmentStatus.Rejected:
+          case AppointmentStatus.Cancelled:
+            appointmentStatusEnum = appointmentStatus as AppointmentStatus;
+            break;
+          default:
+            throw new Error(`Invalid appointment status: ${appointmentStatus}`);
+        }  
+
+        let updatedAppointment = await updateAppointmentStatusAndLocationById(appointmentId, appointmentStatusEnum, appointmentLocation);
+        if (updatedAppointment) {
+          res.json({message: "Appointment Status Successfully Updated", appointment: updatedAppointment})
+        } else {
+            res.json({message: "Something went wrong when updating appointment"});
+            throw new Error("Something went wrong when updating appointment");
+        };
+      };
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
The route is only accessible by professors, it takes an appointmentId, appointmentStatus, and location. The appointment status is a string and I used a switch to match it with our enum. these parameters are passed into the mongo mutation I made and updates the appointmentStatus and sets location. If the appointment is declined we can just leave the location empty.